### PR TITLE
fix: migrate stale dsh-git-rollback file: dep path on extension upgrade

### DIFF
--- a/src/dsh/rollbackInstall.ts
+++ b/src/dsh/rollbackInstall.ts
@@ -119,8 +119,12 @@ function syncManifestDependency(profileDir: string, bundledDir: string): boolean
   if (!existsSync(manifestFile)) return false;
   try {
     const manifest = readJson(manifestFile) as { dependencies?: Record<string, string> };
+    const existing = manifest.dependencies?.[PLUGIN_NAME];
+    // 只处理本扩展自己写入的 file: 依赖:缺失则补上,路径过期(指向已删除的旧版本扩展目录)则迁移。
+    // 用户手动 pin 成 registry/git 版本等非 file: spec 时保持尊重,不覆盖。
+    if (existing !== undefined && !existing.startsWith("file:")) return false;
     const dependency = `file:${bundledDir.replace(/\\/g, "/")}`;
-    if (manifest.dependencies?.[PLUGIN_NAME] === dependency) return false;
+    if (existing === dependency) return false;
     manifest.dependencies = {
       ...(manifest.dependencies ?? {}),
       [PLUGIN_NAME]: dependency,

--- a/src/dsh/rollbackInstall.ts
+++ b/src/dsh/rollbackInstall.ts
@@ -60,8 +60,15 @@ export async function ensureRollbackPluginInstalled(bundledDir: string): Promise
     const installedVersion = existsSync(join(targetDir, VERSION_FILE))
       ? readFileSync(join(targetDir, VERSION_FILE), "utf8").trim()
       : "";
-    if (bundledVersion && installedVersion === bundledVersion) {
-      return { installed: true, changed: false };
+    const filesUpToDate = Boolean(bundledVersion && installedVersion === bundledVersion);
+    if (filesUpToDate) {
+      // 文件已就位:跳过复制,但仍要幂等对齐 file: 依赖 —— 扩展自升级后 bundledDir 会指向
+      // 新版本目录,而 package.json 里的 file: 路径是首次安装时写死的旧目录(升级后已被删除),
+      // 若不迁移,profile 里任何 pnpm / `dsh plugin` 操作都会报 ERR_PNPM_LINKED_PKG_DIR_NOT_FOUND。
+      return {
+        installed: true,
+        changed: syncManifestDependency(profileDir, bundledDir),
+      };
     }
 
     // 1) 复制插件包(先清旧目录,避免残留旧文件)
@@ -94,25 +101,34 @@ export async function ensureRollbackPluginInstalled(bundledDir: string): Promise
       }
     }
 
-    // 3) profile package.json 依赖(file: 指向扩展内置资源,日后 pnpm install 可规范化)
-    const manifestFile = join(profileDir, "package.json");
-    if (existsSync(manifestFile)) {
-      try {
-        const manifest = readJson(manifestFile) as { dependencies?: Record<string, string> };
-        if (!manifest.dependencies?.[PLUGIN_NAME]) {
-          manifest.dependencies = {
-            ...(manifest.dependencies ?? {}),
-            [PLUGIN_NAME]: `file:${bundledDir.replace(/\\/g, "/")}`,
-          };
-          writeFileSync(manifestFile, JSON.stringify(manifest, null, 2) + "\n");
-        }
-      } catch {
-        // profile package.json 损坏时跳过依赖写入,不影响核心安装
-      }
-    }
+    // 3) profile package.json 依赖(file: 指向扩展内置资源,日后 pnpm install 可规范化)。
+    //    与文件复制解耦:即使文件已是最新,只要依赖 key 存在但指向过期路径(扩展升级前
+    //    写入的旧版本目录),也要迁移到当前 bundledDir。
+    syncManifestDependency(profileDir, bundledDir);
+    // 走到这里说明插件文件本次被重新复制(changed=true);依赖迁移作为副作用已同步执行
     return { installed: true, changed: true };
   } catch (error) {
     console.error("[dsh] rollback plugin install failed:", error);
     return { installed: false, changed: false, reason: String(error) };
+  }
+}
+
+/** 幂等对齐 profile package.json 的 file: 依赖:缺失则新增,指向过期路径则迁移到当前 bundledDir。返回是否发生写入。 */
+function syncManifestDependency(profileDir: string, bundledDir: string): boolean {
+  const manifestFile = join(profileDir, "package.json");
+  if (!existsSync(manifestFile)) return false;
+  try {
+    const manifest = readJson(manifestFile) as { dependencies?: Record<string, string> };
+    const dependency = `file:${bundledDir.replace(/\\/g, "/")}`;
+    if (manifest.dependencies?.[PLUGIN_NAME] === dependency) return false;
+    manifest.dependencies = {
+      ...(manifest.dependencies ?? {}),
+      [PLUGIN_NAME]: dependency,
+    };
+    writeFileSync(manifestFile, JSON.stringify(manifest, null, 2) + "\n");
+    return true;
+  } catch {
+    // profile package.json 损坏时跳过依赖写入,不影响核心安装
+    return false;
   }
 }


### PR DESCRIPTION
## 问题现象

`dsh-vscode-pro` 升级后（如 0.11.3 → 0.12.3），VS Code 会删除旧版本扩展目录，但 `~/.dsh/profiles/web/package.json` 里 `dsh-git-rollback` 的 `file:` 依赖仍指向**首次安装时写死的旧版本目录**。该路径已不存在，此后在 profile 里执行任何 pnpm / `dsh plugin add|remove` 都会失败：

```
ERR_PNPM_LINKED_PKG_DIR_NOT_FOUND Could not install from "c:/Users/.../foorgange.dsh-vscode-pro-0.11.3/resources/dsh-git-rollback" as it does not exist.
```

## 根因

`ensureRollbackPluginInstalled()`（src/dsh/rollbackInstall.ts）对 package.json 的 `file:` 依赖只在 **key 不存在时**写入（`if (!manifest.dependencies?.[PLUGIN_NAME])`）：

- 首次安装写入带版本号的扩展目录路径；
- 扩展自升级后 bundledDir 指向新目录，但 key 已存在 → 旧路径永远不会被迁移；
- 若两版扩展内置的 dsh-git-rollback 版本相同（如均为 0.1.7），激活时还会走「版本一致即早退」分支，连依赖检查都不执行。

运行时不受影响（插件装载走 `cordis.patch.yml` + `node_modules` 自维护副本，package.json 仅用于日后 pnpm 规范化），所以问题只在 profile 触发 pnpm 依赖解析时暴露——平时无感，升级扩展后首次执行插件操作时一次性失败。

## 复现步骤

1. 安装 0.11.3 并激活扩展（写入指向 0.11.3 目录的 file: 依赖）；
2. 升级扩展到 0.12.3（旧目录被删除；若内置插件版本未变则激活直接早退）；
3. 执行 `dsh plugin --profile web add <任意插件>` → ERR_PNPM_LINKED_PKG_DIR_NOT_FOUND，错误指向已不存在的 0.11.3 路径。

## 修复

把「file: 依赖对齐」从复制流程中解耦成幂等的 `syncManifestDependency()`，并在两条路径上都执行：

- 依赖缺失 → 新增；
- 依赖存在但指向过期目录 → 迁移到当前 bundledDir；
- 路径已正确 → 不写入（保持幂等）。

这样即使内置插件版本未变（早退路径），激活时也会把过期路径修好；下次扩展升级不再需要手动改 package.json。实测：修复前 `dsh plugin --profile web add` 报错；按此逻辑对齐路径后同一操作成功。
