### PR TITLE
fix(tests): 冒烟测试改为按仓库相对路径解析 esbuild

### DIFF
--- a/tests/smoke/plugin-registry.test.js
+++ b/tests/smoke/plugin-registry.test.js
@@ -1,11 +1,11 @@
 // pluginRegistry 读写 cordis.patch.yml 的冒泡测试(bundle 层 + 注入器 registry + profile patch 合成)
 // 用法: node tests/smoke/plugin-registry.test.js
-const { buildSync } = require("C:/Users/lihe4/Downloads/DeepSeek-Harness-for-VS-Code/node_modules/esbuild");
 const fs = require("fs");
 const os = require("os");
 const path = require("path");
 const repo = path.resolve(__dirname, "..", "..");
 const out = path.join(os.tmpdir(), "registry-test-" + process.pid + ".cjs");
+const { buildSync } = require(path.join(repo, "node_modules/esbuild"));
 buildSync({
   entryPoints: [path.join(repo, "src/dsh/pluginRegistry.ts")],
   bundle: true,

--- a/tests/smoke/store.test.js
+++ b/tests/smoke/store.test.js
@@ -1,11 +1,11 @@
 // SessionStore 投影 emit 链路测试(esbuild 编译后运行)
 // 用法: node tests/smoke/store.test.js
-const { buildSync } = require("C:/Users/lihe4/Downloads/DeepSeek-Harness-for-VS-Code/node_modules/esbuild");
 const fs = require("fs");
 const os = require("os");
 const path = require("path");
 const repo = path.resolve(__dirname, "..", "..");
 const out = path.join(os.tmpdir(), "store-test-" + process.pid + ".cjs");
+const { buildSync } = require(path.join(repo, "node_modules/esbuild"));
 buildSync({
   entryPoints: [path.join(repo, "src/dsh/sessionStore.ts")],
   bundle: true,


### PR DESCRIPTION
## 问题

`tests/smoke/store.test.js` 与 `tests/smoke/plugin-registry.test.js` 用硬编码的绝对路径加载 esbuild：

```js
const { buildSync } = require("C:/Users/lihe4/Downloads/DeepSeek-Harness-for-VS-Code/node_modules/esbuild");
```

除作者本机外，任何环境 `npm test` 都会以 `MODULE_NOT_FOUND` 失败——5 个冒烟测试里有 2 个完全跑不起来；而且 `test` 脚本是 `&&` 串联、第一个就是 `store.test.js`，整条链直接断在这里，后面的测试也不会执行。CI / 贡献者因此无法用测试绿灯做判断。

## 修复

改为相对仓库根解析，与 `settings.test.js` 已有的正确写法保持一致：

```js
const repo = path.resolve(__dirname, "..", "..");
const { buildSync } = require(path.join(repo, "node_modules/esbuild"));
```

## 验证

干净克隆 + `npm install`，在本分支上：

```text
node tests/smoke/store.test.js           -> 17/17 通过
node tests/smoke/plugin-registry.test.js -> 20/20 通过
```

## 说明

- 改动共 2 行，不触碰任何测试逻辑本身；
- `tools/sync-upstream.ps1` 里也有同样的硬编码路径，本 PR 未动——它是维护者侧脚本，可能是有意固定的，需要的话我可以补一个 commit；
- 另外两个 PR（serverManager 的 `starting` 复位、rollback 的 clean exclude）各自新增的测试都挂在 `npm test` 链尾部，只有本 PR 合入后才能在链里真正跑到，三个配合看比较顺。