### PR TITLE
fix(rollback): clean 时排除 .dsh/rollback，避免回退删除其他会话的检查点记录

### DIFF
--- a/package.json
+++ b/package.json
@@ -269,7 +269,7 @@
     "watch": "node esbuild.mjs --watch",
     "package": "npm run build && node tools/clean-releases.mjs && vsce package -o Releases",
     "typecheck": "tsc --noEmit",
-    "test": "node tests/smoke/store.test.js && node tests/smoke/render.test.js && node tests/smoke/artifact.test.js && node tests/smoke/plugin-registry.test.js && node tests/smoke/settings.test.js"
+    "test": "node tests/smoke/store.test.js && node tests/smoke/render.test.js && node tests/smoke/artifact.test.js && node tests/smoke/plugin-registry.test.js && node tests/smoke/settings.test.js && npm --prefix resources/dsh-git-rollback test"
   },
   "dependencies": {
     "dompurify": "^3.2.4",

--- a/resources/dsh-git-rollback/lib/rollback.js
+++ b/resources/dsh-git-rollback/lib/rollback.js
@@ -30,16 +30,18 @@ export function parseTurnArg(rawInput) {
  * 内容级恢复:把工作区+索引恢复成 commit 的树,HEAD/分支引用不动。
  * read-tree 遇未跟踪文件阻碍时先 clean -fd 再重试;最后 reset --quiet 把索引还原回 HEAD
  * (检查点树里"当时未跟踪、现已被还原"的文件重新显示为未跟踪,不污染暂存区)。
+ * clean 必须排除 .dsh/rollback:检查点快照故意不收录该目录,否则回退会删掉所有会话的记录文件。
  */
 async function restoreTreeContent(gitBin, cwd, commit) {
+    const cleanArgs = ["clean", "-fd", "--exclude=.dsh/rollback"];
     const first = await gitExec(gitBin, cwd, ["read-tree", "--reset", "-u", commit]);
     if (!first.ok) {
-        await gitExec(gitBin, cwd, ["clean", "-fd"]);
+        await gitExec(gitBin, cwd, cleanArgs);
         const retry = await gitExec(gitBin, cwd, ["read-tree", "--reset", "-u", commit]);
         if (!retry.ok)
             return { ok: false, reason: `read-tree: ${retry.stderr || first.stderr || "failed"}` };
     }
-    const clean = await gitExec(gitBin, cwd, ["clean", "-fd"]);
+    const clean = await gitExec(gitBin, cwd, cleanArgs);
     const reset = await gitExec(gitBin, cwd, ["reset", "--quiet"]);
     if (!clean.ok || !reset.ok)
         return { ok: false, reason: `clean/reset: ${clean.stderr || reset.stderr || ""}`.trim() };

--- a/resources/dsh-git-rollback/package.json
+++ b/resources/dsh-git-rollback/package.json
@@ -34,7 +34,7 @@
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "typecheck": "tsc -p tsconfig.json --noEmit",
-    "test": "node --test test/git.test.mjs",
+    "test": "node --test test/rollback-clean.test.mjs",
     "prepublishOnly": "npm run build && npm test"
   }
 }

--- a/resources/dsh-git-rollback/test/rollback-clean.test.mjs
+++ b/resources/dsh-git-rollback/test/rollback-clean.test.mjs
@@ -1,0 +1,112 @@
+// C2 regression: rollback's git clean must preserve .dsh/rollback records
+// while still removing other untracked files created after the checkpoint.
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test } from "node:test";
+import { performRollback } from "../lib/rollback.js";
+import { RECORD_DIR } from "../lib/types.js";
+
+const GIT_BIN = "git";
+
+function git(cwd, args) {
+  return execFileSync(GIT_BIN, ["-c", "core.quotepath=false", ...args], {
+    cwd,
+    encoding: "utf8",
+    windowsHide: true,
+  }).trim();
+}
+
+function makeRepo() {
+  const dir = mkdtempSync(join(tmpdir(), "dsh-rb-c2-"));
+  git(dir, ["init"]);
+  git(dir, ["config", "user.email", "t@example.com"]);
+  git(dir, ["config", "user.name", "t"]);
+  writeFileSync(join(dir, "app.js"), "console.log('v1');\n");
+  git(dir, ["add", "app.js"]);
+  git(dir, ["commit", "-m", "init"]);
+  return dir;
+}
+
+/** Build a checkpoint the same way checkpointTurn does (exclude .dsh/rollback from the tree). */
+function makeCheckpoint(dir, message) {
+  git(dir, ["add", "-A"]);
+  git(dir, ["reset", "--quiet", "--", RECORD_DIR]);
+  const tree = git(dir, ["write-tree"]);
+  const parent = git(dir, ["rev-parse", "HEAD"]);
+  return git(dir, [
+    "-c", "commit.gpgsign=false",
+    "commit-tree", tree,
+    "-p", parent,
+    "-m", message,
+  ]);
+}
+
+test("rollback preserves .dsh/rollback records and still cleans other untracked files", async (t) => {
+  const dir = makeRepo();
+  t.after(() => rmSync(dir, { recursive: true, force: true }));
+
+  // Multi-session records: C2 wiped every file under .dsh/rollback
+  mkdirSync(join(dir, RECORD_DIR), { recursive: true });
+  writeFileSync(
+    join(dir, RECORD_DIR, "sessionB.json"),
+    JSON.stringify({ version: 2, sessionId: "sessionB", checkpoints: [], rolls: [] }),
+  );
+
+  // Agent file that exists at checkpoint time (stays after rollback)
+  writeFileSync(join(dir, "helper.js"), "agent work\n");
+  const cp = makeCheckpoint(dir, "dsh-checkpoint sessionA turn 1");
+  assert.match(cp, /^[0-9a-f]{40}$/);
+
+  // Untracked noise created after the checkpoint (must be cleaned by rollback)
+  writeFileSync(join(dir, "noise-after.txt"), "should be cleaned\n");
+  mkdirSync(join(dir, "noise-dir"), { recursive: true });
+  writeFileSync(join(dir, "noise-dir", "x.txt"), "y\n");
+
+  const parent = git(dir, ["rev-parse", "HEAD"]);
+  writeFileSync(
+    join(dir, RECORD_DIR, "sessionA.json"),
+    JSON.stringify({
+      version: 2,
+      sessionId: "sessionA",
+      cwd: dir,
+      checkpoints: [
+        {
+          turn: 1,
+          commit: cp,
+          parent,
+          time: Date.now(),
+          untracked: ["helper.js"],
+          truncated: false,
+        },
+      ],
+      rolls: [],
+    }),
+  );
+
+  const opts = {
+    gitBin: GIT_BIN,
+    refPrefix: "refs/dsh",
+    commitPrefix: "dsh-checkpoint",
+  };
+  const result = await performRollback(GIT_BIN, dir, "sessionA", "1", opts);
+  assert.equal(result.kind, "success", result.text);
+
+  // C2 core: records for all sessions survive
+  assert.ok(existsSync(join(dir, RECORD_DIR, "sessionA.json")), "sessionA.json preserved");
+  assert.ok(existsSync(join(dir, RECORD_DIR, "sessionB.json")), "sessionB.json preserved");
+  assert.equal(
+    JSON.parse(readFileSync(join(dir, RECORD_DIR, "sessionB.json"), "utf8")).sessionId,
+    "sessionB",
+  );
+
+  // Existing rollback behavior: post-checkpoint untracked files are removed
+  assert.equal(existsSync(join(dir, "noise-after.txt")), false, "noise-after.txt cleaned");
+  assert.equal(existsSync(join(dir, "noise-dir")), false, "noise-dir cleaned");
+
+  // Checkpoint content stays available
+  assert.ok(existsSync(join(dir, "app.js")), "tracked baseline preserved");
+  assert.ok(existsSync(join(dir, "helper.js")), "checkpoint-time agent file preserved");
+});


### PR DESCRIPTION
## 问题

`/rollback`（以及 `/redo`）在恢复工作区时，会把**其他会话**的 `.dsh/rollback/<sid>.json` 检查点记录一并删除——多会话工作区里属于静默的数据丢失。

## 根因：两个各自正确的操作叠加

快照阶段，插件故意把自己的记录目录从检查点树中撤出（`checkpoint.js`）：

```js
await gitExec(gitBin, cwd, ["reset", "--quiet", "--", ".dsh/rollback"]);
```

恢复阶段，`restoreTreeContent` 在 `read-tree --reset -u <检查点>` 之后执行**无差别**清理（`rollback.js`）：

```js
const clean = await gitExec(gitBin, cwd, ["clean", "-fd"]);
```

记录文件既不在恢复出的树里、也不在索引里，此刻正好处于 untracked 状态，于是整个 `.dsh/rollback/` 被 `clean` 删掉。注释写的是"删除检查点之后新建的未跟踪文件"，实现却是无 pathspec、无 exclude 的清理。

**影响链**：当前执行回退的会话通常能幸存（记录已在内存中，回退后由 `recordRoll` 回写），但其他会话的记录永久丢失。隐藏 ref 虽在，`foldCheckpoints` 虽能从 ref 链重建回合映射，但**全仓库没有任何调用点**；`/undo` 依赖的 `after` 快照与未跟踪清单一并失效。用户侧表现为：`/rollback N` 报"本会话还没有检查点"、扩展端回退预览空白。

## 实测复现（修复前，调用的是仓库真实插件代码）

```text
checkpointTurn(sessionA) + checkpointTurn(sessionB)   → 两份记录均存在
performRollback(sessionA, "1")                        → success
  .dsh/rollback/sessionA.json  存在
  .dsh/rollback/sessionB.json  不存在   ← 数据丢失
performRollback(sessionB, "1")                        → error: 本会话还没有检查点
```

`/redo` 同样经过 `restoreTreeContent`，同样会删。

## 修复

两处 clean 统一加 exclude（与 `RECORD_DIR` 常量逐字一致）：

```js
const cleanArgs = ["clean", "-fd", "--exclude=.dsh/rollback"];
```

`/rollback`（回合号模式与 SHA 模式）和 `/redo` 共用 `restoreTreeContent`，一处修复覆盖全部恢复路径；`/undo` 走 `git apply -R`，不受影响。若用户自行把 `.dsh` 加入了 `.gitignore`，原本就不会被删——本修复让默认（未 ignore）场景同样安全。

## 验证（新增回归测试）

`resources/dsh-git-rollback/test/rollback-clean.test.mjs`：真实 git 仓库 + 真实 `performRollback`，断言三类用户可观察结果——

- 两个会话的记录文件**均保留**（含记录内容仍可读）；
- 回退后新建的噪音 untracked 文件/目录**照常清理**（防止"修过头"直接去掉 clean）；
- 跟踪文件与检查点期内容正确恢复。

在未修复代码上运行：失败于 `sessionB.json preserved` 断言；修复后通过。

## 顺带说明

- 插件 `package.json` 的 `test` 脚本原本指向不存在的 `test/git.test.mjs`，改为指向本次新增的测试文件；根 `npm test` 链尾追加 `npm --prefix resources/dsh-git-rollback test`；
- 若希望更进一步，可以把 `foldCheckpoints` 接成"记录丢失时从 ref 自动重建"的真实兜底——那属于功能增强，不在本 PR 范围。